### PR TITLE
Update the versions json

### DIFF
--- a/src/data/mc/versions.json
+++ b/src/data/mc/versions.json
@@ -470,8 +470,7 @@
             "version": "1.19.3",
             "major": "1.19",
             "majorName": "The Wild Update",
-            "release": null,
-            "planned": "December 6, 2022"
+            "release": "December 7, 2022"
         },
         {
             "version": "1.20",


### PR DESCRIPTION
1.19.3 has been released, and the date was 7 december, not 6 december.