### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/src/commands/info/instruments.js
+++ b/src/commands/info/instruments.js
@@ -45,7 +45,7 @@ module.exports = {
                     },
                     {
                         name: 'Materials',
-                        value: i.materials.length > 0 ? i.materials.join(', ') + '\n\n _[`More info ↗`](https://minecraft.fandom.com/wiki/Materials#Blocks)_' : '`-`',
+                        value: i.materials.length > 0 ? i.materials.join(', ') + '\n\n _[`More info ↗`](https://minecraft.wiki/w/Materials#Blocks)_' : '`-`',
                         inline: true
                     },
                     {


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.